### PR TITLE
fix: raise kHardMaxSourcePredictedCompileCost to 50000

### DIFF
--- a/compiler/mlir/tools/pycc.cpp
+++ b/compiler/mlir/tools/pycc.cpp
@@ -1098,7 +1098,7 @@ static bool isProbeOnlyFunc(func::FuncOp f) {
   return false;
 }
 
-static constexpr double kHardMaxSourcePredictedCompileCost = 15000.0;
+static constexpr double kHardMaxSourcePredictedCompileCost = 50000.0;
 static constexpr double kHardMaxModulePredictedCompileCost = 40000.0;
 static constexpr double kHardMaxTotalPredictedCompileCost = 700000.0;
 


### PR DESCRIPTION
## Problem

The default `kHardMaxSourcePredictedCompileCost` of 15000 is too small for designs with 64+ module instances. For example, an 8×8 NoC mesh topology reports a predicted compile cost of ~25224, which causes `pycc` to reject the design with error `[PYC991]`.

## Fix

Raise the hard maximum from 15000 to 50000 to provide headroom for large-scale designs while still bounding unreasonable compilation.

## Context

This was discovered while building a 64-node (8×8) mesh NoC topology using pyCircuit. The topology instantiates 64 router modules, each with 5 sub-modules, leading to a predicted compile cost that exceeds the current limit.

A possible future improvement would be to expose this limit as a CLI argument rather than a hardcoded constant, but this minimal fix unblocks large designs in the meantime.