### PR TITLE
feat: configurable reset polarity (active-high / active-low)

### DIFF
--- a/compiler/frontend/pycircuit/cli.py
+++ b/compiler/frontend/pycircuit/cli.py
@@ -666,7 +666,8 @@ def _render_tb_cpp(iface: _TopIface, t: Tb, *, trace_plan: TracePlan | None = No
             "\"global\", pyc::cpp::PycTraceBinWriter::ResetKind::Warm);\n"
         )
         lines.append("  }\n")
-        lines.append(f"  tb.reset(dut.{rst_sn}, /*cyclesAsserted=*/{int(ca)}, /*cyclesDeasserted=*/{int(cd)});\n\n")
+        al = "true" if t.reset_spec.active_low else "false"
+        lines.append(f"  tb.reset(dut.{rst_sn}, /*cyclesAsserted=*/{int(ca)}, /*cyclesDeasserted=*/{int(cd)}, /*activeLow=*/{al});\n\n")
 
     if trace_plan and trace_plan.enabled_signals and trace_plan.window:
         begin = trace_plan.window.begin_cycle
@@ -1002,11 +1003,13 @@ def _render_tb_sv(iface: _TopIface, t: Tb, *, trace_plan: TracePlan | None = Non
             lines.append(f"    rng_{sn} = 64'h{seed64:016x};\n")
     lines.append("\n")
     if has_reset:
-        lines.append(f"    {rst_sn} = 1'b1;\n")
+        assert_val = "1'b0" if t.reset_spec.active_low else "1'b1"
+        deassert_val = "1'b1" if t.reset_spec.active_low else "1'b0"
+        lines.append(f"    {rst_sn} = {assert_val};\n")
         lines.append(f"    repeat ({int(ca)}) @(posedge {clk_sn});\n")
         # Deassert reset away from a posedge to avoid races with posedge-triggered state.
         lines.append(f"    @(negedge {clk_sn});\n")
-        lines.append(f"    {rst_sn} = 1'b0;\n")
+        lines.append(f"    {rst_sn} = {deassert_val};\n")
         lines.append(f"    repeat ({int(cd)}) @(posedge {clk_sn});\n")
         # Ensure cycle 0 starts on a negedge after any post-reset settle cycles.
         lines.append(f"    if ({int(cd)} != 0) @(negedge {clk_sn});\n\n")

--- a/compiler/frontend/pycircuit/tb.py
+++ b/compiler/frontend/pycircuit/tb.py
@@ -132,6 +132,7 @@ class ResetSpec:
     port: str
     cycles_asserted: int = 2
     cycles_deasserted: int = 1
+    active_low: bool = False
 
 
 @dataclass(frozen=True)
@@ -204,7 +205,7 @@ class Tb:
             raise TbError("half_period_steps must be > 0")
         self.clocks.append(ClockSpec(port=p, half_period_steps=hp, phase_steps=int(phase_steps), start_high=bool(start_high)))
 
-    def reset(self, port: str, *, cycles_asserted: int = 2, cycles_deasserted: int = 1) -> None:
+    def reset(self, port: str, *, cycles_asserted: int = 2, cycles_deasserted: int = 1, active_low: bool = False) -> None:
         p = str(port).strip()
         if not p:
             raise TbError("reset port must be non-empty")
@@ -212,7 +213,7 @@ class Tb:
         cd = int(cycles_deasserted)
         if ca < 0 or cd < 0:
             raise TbError("reset cycles must be >= 0")
-        self.reset_spec = ResetSpec(port=p, cycles_asserted=ca, cycles_deasserted=cd)
+        self.reset_spec = ResetSpec(port=p, cycles_asserted=ca, cycles_deasserted=cd, active_low=bool(active_low))
 
     def drive(self, port: str, value: int | bool, *, at: int) -> None:
         p = str(port).strip()

--- a/compiler/frontend/pycircuit/testbench.py
+++ b/compiler/frontend/pycircuit/testbench.py
@@ -100,6 +100,7 @@ def testbench_payload_from_tb(
                 "port": str(tb.reset_spec.port),
                 "cycles_asserted": int(tb.reset_spec.cycles_asserted),
                 "cycles_deasserted": int(tb.reset_spec.cycles_deasserted),
+                "active_low": bool(tb.reset_spec.active_low),
             }
         ),
         drives=tuple({"port": str(d.port), "value": int(d.value), "at": int(d.at)} for d in tb.drives),

--- a/runtime/cpp/pyc_primitives.hpp
+++ b/runtime/cpp/pyc_primitives.hpp
@@ -65,7 +65,7 @@ struct pyc_not {
   void eval() { y = ~a; }
 };
 
-template <unsigned Width>
+template <unsigned Width, bool RstActiveLow = false>
 class pyc_reg {
 public:
   pyc_reg(Wire<1> &clk, Wire<1> &rst, Wire<1> &en, Wire<Width> &d, Wire<Width> &init, Wire<Width> &q)
@@ -79,7 +79,8 @@ public:
     if (!posedge)
       return;
 
-    if (rst.toBool()) {
+    bool rstActive = RstActiveLow ? !rst.toBool() : rst.toBool();
+    if (rstActive) {
       pending = true;
       qNext = init;
       return;
@@ -110,7 +111,7 @@ public:
   Wire<Width> qNext{};
 };
 
-template <unsigned Width, unsigned Depth>
+template <unsigned Width, unsigned Depth, bool RstActiveLow = false>
 class pyc_fifo {
 public:
   pyc_fifo(Wire<1> &clk,
@@ -164,7 +165,8 @@ public:
       return;
 
     pending = true;
-    if (rst.toBool()) {
+    bool rstActive = RstActiveLow ? !rst.toBool() : rst.toBool();
+    if (rstActive) {
       rdNext_ = 0;
       wrNext_ = 0;
       countNext_ = 0;

--- a/runtime/cpp/pyc_tb.hpp
+++ b/runtime/cpp/pyc_tb.hpp
@@ -279,10 +279,10 @@ public:
     }
   }
 
-  void reset(Wire<1> &rst, std::uint64_t cyclesAsserted = 2, std::uint64_t cyclesDeasserted = 1) {
-    rst = Wire<1>(1);
+  void reset(Wire<1> &rst, std::uint64_t cyclesAsserted = 2, std::uint64_t cyclesDeasserted = 1, bool activeLow = false) {
+    rst = Wire<1>(activeLow ? 0u : 1u);
     runCycles(cyclesAsserted);
-    rst = Wire<1>(0);
+    rst = Wire<1>(activeLow ? 1u : 0u);
     runCycles(cyclesDeasserted);
   }
 

--- a/runtime/verilog/pyc_fifo.v
+++ b/runtime/verilog/pyc_fifo.v
@@ -1,7 +1,8 @@
 // Ready/valid FIFO with synchronous reset (prototype).
 module pyc_fifo #(
   parameter WIDTH = 1,
-  parameter DEPTH = 2
+  parameter DEPTH = 2,
+  parameter RST_ACTIVE_LOW = 0
 ) (
   input             clk,
   input             rst,
@@ -37,6 +38,8 @@ module pyc_fifo #(
 
   localparam PTR_W = (DEPTH <= 1) ? 1 : pyc_clog2(DEPTH);
 
+  wire rst_active = RST_ACTIVE_LOW ? ~rst : rst;
+
   reg [WIDTH-1:0] storage [0:DEPTH-1];
   reg [PTR_W-1:0] rd_ptr;
   reg [PTR_W-1:0] wr_ptr;
@@ -65,7 +68,7 @@ module pyc_fifo #(
   endfunction
 
   always @(posedge clk) begin
-    if (rst) begin
+    if (rst_active) begin
       rd_ptr <= {PTR_W{1'b0}};
       wr_ptr <= {PTR_W{1'b0}};
       count <= {(PTR_W + 1){1'b0}};

--- a/runtime/verilog/pyc_reg.v
+++ b/runtime/verilog/pyc_reg.v
@@ -1,6 +1,7 @@
 // Simple synchronous reset register (prototype).
 module pyc_reg #(
-  parameter WIDTH = 1
+  parameter WIDTH = 1,
+  parameter RST_ACTIVE_LOW = 0
 ) (
   input             clk,
   input             rst,
@@ -9,8 +10,9 @@ module pyc_reg #(
   input  [WIDTH-1:0] init,
   output reg [WIDTH-1:0] q
 );
+  wire rst_active = RST_ACTIVE_LOW ? ~rst : rst;
   always @(posedge clk) begin
-    if (rst)
+    if (rst_active)
       q <= init;
     else if (en)
       q <= d;

--- a/tests/test_reset_polarity.py
+++ b/tests/test_reset_polarity.py
@@ -1,0 +1,108 @@
+"""Tests for configurable reset polarity (feat: reset polarity).
+
+Verifies that:
+1. ResetSpec supports active_low flag (default False)
+2. Tb.reset() accepts active_low parameter
+3. Serialized reset dict includes active_low field
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pycircuit.tb import ResetSpec, Tb, TbError
+
+
+class TestResetSpec:
+    """ResetSpec dataclass supports active_low field."""
+
+    def test_default_active_high(self) -> None:
+        spec = ResetSpec(port="rst")
+        assert spec.active_low is False
+        assert spec.cycles_asserted == 2
+        assert spec.cycles_deasserted == 1
+
+    def test_active_low(self) -> None:
+        spec = ResetSpec(port="rst_n", active_low=True)
+        assert spec.active_low is True
+
+    def test_frozen(self) -> None:
+        spec = ResetSpec(port="rst", active_low=True)
+        with pytest.raises(AttributeError):
+            spec.active_low = False  # type: ignore[misc]
+
+    def test_backward_compat(self) -> None:
+        """Constructing without active_low should always work."""
+        spec = ResetSpec(port="rst", cycles_asserted=3, cycles_deasserted=2)
+        assert spec.active_low is False
+
+
+class TestTbResetAPI:
+    """Tb.reset() method accepts active_low parameter."""
+
+    def test_default(self) -> None:
+        t = Tb()
+        t.reset("rst")
+        assert t.reset_spec is not None
+        assert t.reset_spec.active_low is False
+
+    def test_active_low(self) -> None:
+        t = Tb()
+        t.reset("rst_n", active_low=True)
+        assert t.reset_spec is not None
+        assert t.reset_spec.active_low is True
+        assert t.reset_spec.port == "rst_n"
+
+    def test_active_high_explicit(self) -> None:
+        t = Tb()
+        t.reset("rst", active_low=False)
+        assert t.reset_spec is not None
+        assert t.reset_spec.active_low is False
+
+    def test_with_cycles(self) -> None:
+        t = Tb()
+        t.reset("rst_n", cycles_asserted=5, cycles_deasserted=3, active_low=True)
+        assert t.reset_spec.cycles_asserted == 5
+        assert t.reset_spec.cycles_deasserted == 3
+        assert t.reset_spec.active_low is True
+
+
+class TestResetSerialization:
+    """Reset serialization dict includes active_low."""
+
+    @staticmethod
+    def _serialize_reset(spec: ResetSpec) -> dict:
+        """Replicates the serialization logic from testbench.py."""
+        return {
+            "port": str(spec.port),
+            "cycles_asserted": int(spec.cycles_asserted),
+            "cycles_deasserted": int(spec.cycles_deasserted),
+            "active_low": bool(spec.active_low),
+        }
+
+    def test_active_low_serialized(self) -> None:
+        spec = ResetSpec(port="rst_n", active_low=True)
+        d = self._serialize_reset(spec)
+        assert d["active_low"] is True
+        assert d["port"] == "rst_n"
+
+    def test_active_high_serialized(self) -> None:
+        spec = ResetSpec(port="rst")
+        d = self._serialize_reset(spec)
+        assert d["active_low"] is False
+
+    def test_roundtrip_from_tb(self) -> None:
+        """Tb.reset() → ResetSpec → serialization → dict."""
+        t = Tb()
+        t.reset("rst_n", cycles_asserted=4, active_low=True)
+        d = self._serialize_reset(t.reset_spec)
+        assert d == {
+            "port": "rst_n",
+            "cycles_asserted": 4,
+            "cycles_deasserted": 1,
+            "active_low": True,
+        }
+
+    def test_no_reset(self) -> None:
+        t = Tb()
+        assert t.reset_spec is None


### PR DESCRIPTION
## Motivation

pyCircuit primitives (`pyc_reg`, `pyc_fifo`) currently hardcode active-high reset (`if (rst)`). Many real-world designs use active-low reset signals (`rst_n`), requiring users to manually patch all generated primitives after every Verilog export.

## Changes

### Verilog Primitives
- **`pyc_reg.v`**: Added `RST_ACTIVE_LOW` parameter (default `0`). Internally derives `rst_active = RST_ACTIVE_LOW ? ~rst : rst`.
- **`pyc_fifo.v`**: Same `RST_ACTIVE_LOW` parameter.

### C++ Primitives
- **`pyc_primitives.hpp`**: Added `RstActiveLow` template parameter (default `false`) to `pyc_reg` and `pyc_fifo`.

### C++ Testbench Runtime
- **`pyc_tb.hpp`**: `Testbench::reset()` now accepts `activeLow` parameter, using `0` for assert and `1` for deassert when true.

### Python Frontend
- **`tb.py`**: `ResetSpec` gains `active_low: bool = False` field. `Tb.reset()` gains corresponding parameter.
- **`testbench.py`**: Serializes `active_low` field into testbench payload JSON.
- **`cli.py`**: Both C++ and SV testbench generators respect the polarity flag, emitting correct assert/deassert signal levels.

### Usage

```python
@testbench
def tb(t: Tb) -> None:
    t.clock("clk")
    t.reset("rst_n", active_low=True)  # active-low reset
    ...
```

## Backward Compatibility

All defaults remain `active_low=False` / `RST_ACTIVE_LOW=0` / `RstActiveLow=false`, so existing designs are unaffected.

## Tests

12 unit tests covering `ResetSpec`/`Tb.reset()` API and serialization.